### PR TITLE
fix django to 1.8.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
                       'boto3',
                       'pytz',
                       'Pillow',
-                      'django',
+                      'Django >=1.8.7, < 1.9a0',
                       'gsconfig',
                       'requests',
                       'shapely',


### PR DESCRIPTION
Django 2.0 was released on December 2nd and is now being pulled in when installing nearsight.