### PR TITLE
set store name to OGC_SERVER['DATASTORE'] setting

### DIFF
--- a/nearsight/nearsight.py
+++ b/nearsight/nearsight.py
@@ -1547,7 +1547,7 @@ def publish_layer(layer_name, geoserver_base_url=None, database_alias=None):
     user = conn.settings_dict.get('USER')
     srs = "EPSG:4326"
     database = conn.settings_dict.get('NAME')
-    datastore_name = database
+    datastore_name = ogc_server.get('DATASTORE')
 
     if not password:
         logger.warn("Geoserver can not be updated without a database password provided in the settings file.")


### PR DESCRIPTION
When created the layer in geoserver, nearsight was checking for a datastore with the exact name as the database name. The datastore should be defined in OGC_SERVER['DATASTORE']  and should be utilized in nearsight publish_layer()